### PR TITLE
Fix csp error for js myx ext

### DIFF
--- a/editor-server/public/editor.html
+++ b/editor-server/public/editor.html
@@ -1,13 +1,9 @@
 <!DOCTYPE html>
-<html><head><title>Mock Editor</title></head>
+<html>
+<head>
+    <title>Mock Editor</title>
+</head>
 <body>
-  <script>
-    // Log incoming messages
-    window.addEventListener('message', e => {
-      console.log('Editor received:', e.data, 'from', e.origin);
-    });
-    // Notify parent when loaded
-    parent.postMessage({type:'iframeLoaded'}, 'http://localhost:5000');
-    console.log('Editor iframe loaded, sent ready message');
-  </script>
-</body></html>
+    <script src="editor.js"></script>
+</body>
+</html>

--- a/editor-server/public/editor.js
+++ b/editor-server/public/editor.js
@@ -1,0 +1,29 @@
+// Log incoming messages
+window.addEventListener('message', e => {
+  try {
+    // Ensure we're receiving from expected origin
+    if (e.origin !== 'http://localhost:5000') {
+      console.warn('Received message from unexpected origin:', e.origin);
+      return;
+    }
+
+    // Parse incoming data if it's a string
+    const data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+    console.log('Editor received:', data);
+
+  } catch (error) {
+    console.error('Error processing message:', error);
+  }
+});
+
+// Notify parent when loaded
+try {
+  const message = { 
+    type: 'iframeLoaded',
+    timestamp: Date.now()
+  };
+  parent.postMessage(JSON.stringify(message), 'http://localhost:5000');
+  console.log('Editor iframe loaded, sent ready message');
+} catch (error) {
+  console.error('Error sending ready message:', error);
+}

--- a/minimal_repro/lib/main.dart
+++ b/minimal_repro/lib/main.dart
@@ -4,35 +4,76 @@ import 'package:flutter/material.dart';
 import 'package:web/web.dart' as web;
 import 'dart:ui_web' as ui_web;
 
-@JS()
-@staticInterop
-extension type WindowExtension._(JSObject _) implements JSObject {
-  external void postMessage(JSAny message, JSString targetOrigin);
-}
+// JS interop for the bridge defined in index.html
+@JS('jsMyx')
+external JSObject get jsMyx;
 
-extension WindowCasting on web.Window {
-  WindowExtension get ext => this as WindowExtension;
+extension JsMyxExt on JSObject {
+  external void postMessage(web.HTMLIFrameElement iframe, String msg);
 }
 
 class EditorController {
   web.HTMLIFrameElement? _iframe;
+  bool _iframeLoaded = false;
+  final _messageQueue = <Map<String, dynamic>>[];
+
   void setIframe(web.HTMLIFrameElement iframe) {
     _iframe = iframe;
+    _setupListeners(iframe);
   }
 
-  void sendMessage(dynamic msg) {
-    final jsonMsg = jsonEncode(msg);
-    final cw = _iframe?.contentWindow;
-    if (cw == null) {
-      debugPrint('Cannot send—window is null');
+  void _setupListeners(web.HTMLIFrameElement iframe) {
+    // Handle iframe load
+    iframe.onLoad.listen((_) {
+      _iframeLoaded = true;
+      _processQueue();
+    });
+
+    // Handle incoming messages
+    web.window.onMessage.listen((event) {
+      if (event.origin == 'http://localhost:3005') {
+        try {
+          final data = jsonDecode((event.data as JSString).toDart);
+          debugPrint('Received: $data');
+
+          if (data is Map && data['type'] == 'iframeLoaded') {
+            _iframeLoaded = true;
+            _processQueue();
+          }
+        } catch (e) {
+          debugPrint('Message parse error: $e');
+        }
+      }
+    });
+  }
+
+  void _processQueue() {
+    if (!_iframeLoaded) return;
+
+    for (final msg in _messageQueue) {
+      sendMessage(msg);
+    }
+    _messageQueue.clear();
+  }
+
+  void sendMessage(Map<String, dynamic> msg) {
+    if (!_iframeLoaded) {
+      _messageQueue.add(msg);
+      debugPrint('Queued message: $msg');
       return;
     }
+
     try {
-      // targetOrigin matches editor server
-      cw.ext.postMessage(jsonMsg.toJS, 'http://localhost:3005'.toJS);
-      debugPrint('Message sent: $jsonMsg');
+      final jsonMsg = jsonEncode(msg);
+      if (_iframe == null) {
+        debugPrint('No iframe available');
+        return;
+      }
+      // Use the extension method for type-safe interop
+      JsMyxExt(jsMyx).postMessage(_iframe!, jsonMsg);
+      debugPrint('Sent message: $jsonMsg');
     } catch (e) {
-      debugPrint('Error sending message: $e');
+      debugPrint('Send error: $e');
     }
   }
 }
@@ -41,6 +82,8 @@ void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
   final EditorController ctrl = EditorController();
+
+  MyApp({super.key});
   @override
   Widget build(BuildContext ctx) {
     return MaterialApp(

--- a/minimal_repro/lib/main.dart
+++ b/minimal_repro/lib/main.dart
@@ -33,10 +33,17 @@ class EditorController {
     web.window.onMessage.listen((event) {
       if (event.origin == 'http://localhost:3005') {
         try {
-          final data = jsonDecode((event.data as JSString).toDart);
-          debugPrint('Received: $data');
+          // Convert event.data to a Dart String
+          final rawData = event.data;
+          debugPrint('Event type: ${event.type}');
+          debugPrint('Raw data type: ${rawData.runtimeType}');
+          final data =
+              rawData is JSString ? rawData.toDart : rawData.toString();
 
-          if (data is Map && data['type'] == 'iframeLoaded') {
+          final decodedData = jsonDecode(data);
+          debugPrint('Received: $decodedData');
+
+          if (decodedData is Map && decodedData['type'] == 'iframeLoaded') {
             _iframeLoaded = true;
             _processQueue();
           }

--- a/minimal_repro/web/index.html
+++ b/minimal_repro/web/index.html
@@ -1,21 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <!--
-    If you are serving your web app in a path other than the root, change the
-    href value below to reflect the base path you are serving from.
-
-    The path provided below has to start and end with a slash "/" in order for
-    it to work correctly.
-
-    For more details:
-    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
-
-    This is a placeholder for base href that will be replaced by the value of
-    the `--base-href` argument provided to `flutter build`.
-  -->
   <base href="$FLUTTER_BASE_HREF">
-
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="A new Flutter project.">
@@ -33,6 +19,16 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
+  <!-- Add your JS bridge here -->
+  <script>
+    window.jsMyx = {
+      postMessage: function(iframeElt, msg) {
+        if (iframeElt && iframeElt.contentWindow) {
+          iframeElt.contentWindow.postMessage(msg, 'http://localhost:3005');
+        }
+      }
+    };
+  </script>
   <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "CommunicationErrorMRE",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This pull request introduces several updates to improve the communication between the Flutter app and the embedded editor iframe, refactor the messaging logic, and enhance maintainability. The most important changes include extracting the iframe message handling logic into a dedicated JavaScript file, adding a JavaScript bridge for safe interop between Dart and JS, and improving error handling and message queuing in the Dart `EditorController`.

### Messaging and iframe communication improvements:
* Extracted the inline JavaScript from `editor.html` into a new `editor.js` file, improving separation of concerns. Enhanced the message handling logic to validate the origin and parse incoming messages safely. [[1]](diffhunk://#diff-91b1179caae9375407147e00b14407373199bf3e417892d94780caed218dd423L2-R9) [[2]](diffhunk://#diff-c6856afafd9a81302659d7e52170c4d4d4709d9ef13c98c463e8659728f0584dR1-R29)
* Added a JavaScript bridge (`jsMyx`) in `index.html` to facilitate safe and type-checked communication between Dart and the iframe. This bridge ensures that messages are sent to the correct iframe and origin.

### Dart `EditorController` refactoring:
* Replaced the old JS interop extension (`WindowExtension`) with the new `jsMyx` bridge for more robust and maintainable communication.
* Improved the `EditorController` to handle iframe load events, queue messages until the iframe is ready, and process the queue once the iframe signals readiness. Enhanced error handling and debug logging for better traceability.

### Minor changes:
* Removed unnecessary comments and cleaned up `index.html` to improve readability.
* Added a constructor to `MyApp` in `main.dart` for consistency.